### PR TITLE
Fixed typographical error, changed Cambrige to Cambridge in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Conférences et présentations de l'équipe R&D du [comparateur d'assurance LesF
 - 5 mars 2015 (français) : [BBL chez Viseo - Continuous Delivery chez LesFurets.com](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-BBL-viseo.html)
 - 25 février 2015 (français) : [Continuous Delivery Meetup - Continuous Delivery chez LesFurets.com](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-lean-kanban-france-2014.html)
 - 1 novembre 2014 (français) : [LeanKanban France 2014 - Continuous Delivery chez LesFurets.com](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-lean-kanban-france-2014.html)
-- 1 octobre 2014 (anglais) : [Agile Cambrige 2014 - Continuous Delivery the french way](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-agile-cambridge-2014.html)
+- 1 octobre 2014 (anglais) : [Agile Cambridge 2014 - Continuous Delivery the french way](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-agile-cambridge-2014.html)
 - 1 octobre 2014 (français) : [AgileTour Rennes 2014 - Continuous Delivery chez LesFurets.com](https://lesfurets.github.io/lesfurets-conferences/continuous-delivery-agile-tour-rennes-2014.html)
 
 ## Vidéos


### PR DESCRIPTION
lesfurets, I've corrected a typographical error in the documentation of the [lesfurets-conferences](https://github.com/lesfurets/lesfurets-conferences) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
